### PR TITLE
#592 Use term vector for large field highlighting

### DIFF
--- a/app/Services/MetadataService.php
+++ b/app/Services/MetadataService.php
@@ -1498,6 +1498,7 @@ class MetadataService extends Service
                     'pdf_text_string' =>
                         [
                             'type' => 'text',
+                            'term_vector' => 'with_positions_offsets',
                             'fields' =>
                                 [
                                     'keyword' =>


### PR DESCRIPTION
NRGI/nrgi-dcos#592
ES 7.x limits higlighting on fields for 100k characters. For larger fields, using a term vector with positions offsets is recommended.